### PR TITLE
Correct Modulus

### DIFF
--- a/bigint.lua
+++ b/bigint.lua
@@ -460,7 +460,7 @@ function bigint.divide_raw(big1, big2)
     if (bigint.compare(big1, big2, "==")) then
         return bigint.new(1), bigint.new(0)
     elseif (bigint.compare(big1, big2, "<")) then
-        return bigint.new(0), bigint.new(0)
+        return bigint.new(0), big1:clone()
     else
         assert(bigint.compare(big2, bigint.new(0), "!="), "error: divide by zero")
         assert(big1.sign == "+", "error: big1 is not positive")


### PR DESCRIPTION
When using bigint for modulus of something such as 2 % 13, the library returns 0 instead of 2. Corrected by changing the divide raw function to return 2 as the remainder instead of 0 when the dividend is less than the divisor.